### PR TITLE
Use __dirname instead of process.cwd

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,7 @@ export default function esbuildPluginPino({
 
         const contents = await readFile(args.path, 'utf8')
 
-        const absoluteOutputPath = `\${process.cwd()}\${require('path').sep}${
+        const absoluteOutputPath = `\${__dirname}\${require('path').sep}${
           currentBuild.initialOptions.outdir || 'dist'
         }`
 


### PR DESCRIPTION
This works better when you are in the context of a CLI/install module.